### PR TITLE
Manage "--skip-fs-checks" option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN yum install -y /rpms/vertica.rpm
 RUN /opt/vertica/sbin/install_vertica --license CE --accept-eula --hosts 127.0.0.1 --dba-user-password-disabled --failure-threshold NONE --no-system-configuration
 
 USER dbadmin
-RUN /opt/vertica/bin/admintools -t create_db -s localhost --skip-fs-checks -d docker -c /home/dbadmin/docker/catalog -D /home/dbadmin/docker/data
+RUN /opt/vertica/bin/admintools -t create_db -s localhost --skip-fs-checks -d docker -c /home/dbadmin/docker/catalog -D /home/dbadmin/docker/data --skip-fs-checks
 USER root
 
 RUN mkdir /tmp/.python-eggs


### PR DESCRIPTION
avoid blocking warning if using an external mountpoint ("-v" option) with 8.0.0 version of HPVertica server